### PR TITLE
Configurable SSL/TLS key type

### DIFF
--- a/mypaas/server/_init.py
+++ b/mypaas/server/_init.py
@@ -97,8 +97,8 @@ def _collect_info_for_config():
     key_types = ['EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192']
     print(f"Key Types: {key_types}")
     # https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-    print("Mozilla Recommends EC256, but some old clients (like IE on Windows XP) only support RSA choices")
-    print("EC256 uses significantly less CPU than RSA; Traefik defaults to RSA4096 for compatibility")
+    print("Mozilla recommends EC256; some old clients (IE on Windows XP) only support RSA")
+    print("EC uses far less CPU than RSA; Traefik defaults to RSA4096 for compatibility")
     key_type = input("    SSL/TLS Key Type: ").strip("' ")
     if key_type not in key_types:
         sys.exit(f"Invalid Key Type: {key_type}")

--- a/mypaas/server/_init.py
+++ b/mypaas/server/_init.py
@@ -91,9 +91,20 @@ def _collect_info_for_config():
     print("Let's Encrypt can send an email when something is wrong.")
     print()
     email = input("    Email for Let's Encrypt (optional): ").strip()
+
+    print()
+    print("Traefik can use different key types for SSL/TLS certificates.")
+    key_types = ['EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192']
+    print(f"Key Types: {key_types}")
+    # https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+    print("Mozilla Recommends EC256, but some old clients (like IE on Windows XP) only support RSA choices")
+    print("EC256 uses significantly less CPU than RSA; Traefik defaults to RSA4096 for compatibility")
+    key_type = input("    SSL/TLS Key Type: ").strip("' ")
+    if key_type not in key_types:
+        sys.exit(f"Invalid Key Type: {key_type}")
     print()
 
-    return {"domain": domain, "web_credentials": f"{username}:{pwhash}", "email": email}
+    return {"domain": domain, "web_credentials": f"{username}:{pwhash}", "email": email, "key_type": key_type}
 
 
 def _get_password_hash(pw):

--- a/mypaas/server/_traefik.py
+++ b/mypaas/server/_traefik.py
@@ -63,6 +63,7 @@ def init_router():
     # Create the static config
     print("Writing Traefik config")
     text = traefik_config.replace("EMAIL", config["init"]["email"])
+    text = text.replace("KEY_TYPE", config["init"]["key_type"])
     with open(os.path.join(traefik_dir, "traefik.toml"), "wb") as f:
         f.write(text.encode())
 
@@ -111,6 +112,7 @@ traefik_config = """
 [certificatesResolvers.default.acme]
   email = "EMAIL"
   storage = "acme.json"
+  keyType = "KEY_TYPE"
   [certificatesResolvers.default.acme.httpchallenge]
     entrypoint = "web"
 


### PR DESCRIPTION
This will allow the user to set the certificate key type. This probably seems like such a low-level thing to ask a user to choose in such a simple PaaS system, but the default (RSA4096) means that Traefik is using around 300% CPU on my server while it only uses around 40% CPU with EC256.

To make a long story a little shorter, people have noticed that Traefik is slow and uses a lot of CPU when using RSA4096 (https://github.com/traefik/traefik/issues/2673#issuecomment-472348299).  There was a PR a couple years ago to switch to ECDSA/EC256 as the default, but they decided that they didn’t want to change it until Traefik supported dual-certs (https://github.com/traefik/traefik/pull/4993). Dual-cert functionality hasn’t happened in the interim (https://github.com/traefik/traefik/issues/3483).

Cloudflare notes that ECDSA reduces the cost of the private key operation by a factor of 9.5x (https://blog.cloudflare.com/ecdsa-the-digital-signature-algorithm-of-a-better-internet/).

I didn’t think it would be right to just switch it to EC256 given Traefik’s decision so I decided to ask the user.  It feels weird to ask, but given the huge performance implication and the amount of searching I did to find why Traefik was slow, maybe it’s reasonable?  With RSA4096, Traefik was using nearly 10x more CPU than the MyPaas dashboard written in Python.

Did I put in too much explanation? Too little?  If this isn’t something you want in the project, I can just keep my own branch to set EC256 for me.
