### PR TITLE
switch keyType to ECDSA/EC256

### DIFF
--- a/mypaas/server/_traefik.py
+++ b/mypaas/server/_traefik.py
@@ -110,6 +110,7 @@ traefik_config = """
 # Enable Let's Encrypt
 [certificatesResolvers.default.acme]
   email = "EMAIL"
+  keyType = "EC256"
   storage = "acme.json"
   [certificatesResolvers.default.acme.httpchallenge]
     entrypoint = "web"


### PR DESCRIPTION
To make a long story a little shorter, people have noticed that Traefik is slow and uses a lot of CPU when using RSA4096 (traefik/traefik#2673 (comment)). There was a PR a couple years ago to switch to ECDSA/EC256 as the default, but they decided that they didn’t want to change it until Traefik supported dual-certs (traefik/traefik#4993). Dual-cert functionality hasn’t happened in the interim (traefik/traefik#3483).

Cloudflare notes that ECDSA reduces the cost of the private key operation by a factor of 9.5x (https://blog.cloudflare.com/ecdsa-the-digital-signature-algorithm-of-a-better-internet/).  On my server, CPU usage went down from 300% to 40% for Traefik.

ECDSA won't work with IE on Windows XP.  Edit /root/_mypaas/traefik.toml to switch to RSA4096 if you want to support IE on Windows XP.

If you are using a proxy/CDN like Cloudflare, you don't need to worry about ECDSA support since Cloudflare is handling the TLS connection to the client.