### PR TITLE
Disable really old cipher suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![PyPI Version](https://img.shields.io/pypi/v/mypaas.svg)](https://pypi.python.org/pypi/mypaas/)
-[![CI](https://github.com/almarklein/mypaas/workflows/CI/badge.svg?branch=master)](https://github.com/almarklein/mypaas/actions)
+[![CI](https://github.com/almarklein/mypaas/workflows/CI/badge.svg?branch=main)](https://github.com/almarklein/mypaas/actions)
 
 <img src="docs/screenshots/dashboard1.png" height=192></img>
 <img src="docs/screenshots/dashboard3.png" height=192></img>
@@ -62,7 +62,7 @@ development skills. There are plenty of online guides on each topic.
 * [The CLI](docs/cli.md)
 * [Notes on security](docs/security.md)
 
-Also see the [example services](https://github.com/almarklein/mypaas/tree/master/example_services).
+Also see the [example services](https://github.com/almarklein/mypaas/tree/main/example_services).
 
 
 ## License

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -38,9 +38,9 @@ Now install MyPaas. It is written in Python, so we use pip to install it (you'll
 PaaS-server$ apt install python3-pip
 PaaS-server$ pip3 install mypaas[server]
 ```
-Or to install the current master:
+Or to install the current main branch:
 ```
-PaaS-server$ pip3 install -U git+https://github.com/almarklein/mypaas.git@master#egg=mypaas[server]
+PaaS-server$ pip3 install -U git+https://github.com/almarklein/mypaas.git@main#egg=mypaas[server]
 ```
 
 That's it, you can now initialize your server:

--- a/example_services/minimal/Dockerfile
+++ b/example_services/minimal/Dockerfile
@@ -1,8 +1,8 @@
 # mypaas.service = minimal
 #
-# mypaas.url = https://example.com/minimal
+# mypaas.url = https://test2.canpute.com
 #
-# mypaas.scale = 3
+# mypaas.scale = 0
 # mypaas.healthcheck = /status 11s 2s
 # mypaas.maxmem = 500m
 

--- a/example_services/minimal/Dockerfile
+++ b/example_services/minimal/Dockerfile
@@ -1,8 +1,8 @@
 # mypaas.service = minimal
 #
-# mypaas.url = https://test2.canpute.com
+# mypaas.url = https://example.com/minimal
 #
-# mypaas.scale = 0
+# mypaas.scale = 3
 # mypaas.healthcheck = /status 11s 2s
 # mypaas.maxmem = 500m
 

--- a/example_services/minimal/Dockerfile
+++ b/example_services/minimal/Dockerfile
@@ -2,7 +2,7 @@
 #
 # mypaas.url = https://test2.canpute.com
 #
-# mypaas.scale = 0
+# mypaas.scale = 3
 # mypaas.healthcheck = /status 11s 2s
 # mypaas.maxmem = 500m
 

--- a/example_services/minimal/Dockerfile
+++ b/example_services/minimal/Dockerfile
@@ -2,7 +2,7 @@
 #
 # mypaas.url = https://test2.canpute.com
 #
-# mypaas.scale = 3
+# mypaas.scale = 0
 # mypaas.healthcheck = /status 11s 2s
 # mypaas.maxmem = 500m
 

--- a/mypaas/server/_deploy.py
+++ b/mypaas/server/_deploy.py
@@ -204,7 +204,7 @@ def get_deploy_generator(deploy_dir):
             label(f"traefik.http.routers.{router_name}.rule={rule}")
             label(f"traefik.http.routers.{router_name}.entrypoints=web-secure")
             label(f"traefik.http.routers.{router_name}.tls.certresolver=default")
-            label(f"traefik.http.routers.{router_name}.tls.options=intermediate")
+            label(f"traefik.http.routers.{router_name}.tls.options=intermediate@file")
             label(f"traefik.http.routers.{router_name}.middlewares=hsts-header@file")
             # Redirect
             label(f"traefik.http.routers.{router_insec}.rule={rule}")

--- a/mypaas/server/_deploy.py
+++ b/mypaas/server/_deploy.py
@@ -335,7 +335,7 @@ def _deploy_scale(container_infos, deploy_dir, service_name, prepared_cmd, scale
     # In essence, we dont want to close the last old container before the first
     # new container is fully operational.
     max_time_we_expect_a_container_to_boot = 5
-    pause_per_step = 1 + max_time_we_expect_a_container_to_boot / len(old_pool)
+    pause_per_step = 1 + max_time_we_expect_a_container_to_boot / max(1, len(old_pool))
 
     try:
         for i in range(scale):

--- a/mypaas/server/_deploy.py
+++ b/mypaas/server/_deploy.py
@@ -204,7 +204,7 @@ def get_deploy_generator(deploy_dir):
             label(f"traefik.http.routers.{router_name}.rule={rule}")
             label(f"traefik.http.routers.{router_name}.entrypoints=web-secure")
             label(f"traefik.http.routers.{router_name}.tls.certresolver=default")
-            label(f"traefik.http.routers.{router_name}.tls.options=intermediate@file")
+            label(f"traefik.http.routers.{router_name}.tls.options=intermediate")
             label(f"traefik.http.routers.{router_name}.middlewares=hsts-header@file")
             # Redirect
             label(f"traefik.http.routers.{router_insec}.rule={rule}")

--- a/mypaas/server/_deploy.py
+++ b/mypaas/server/_deploy.py
@@ -200,9 +200,13 @@ def get_deploy_generator(deploy_dir):
                     f"URL {url.netloc + url.path} is already used in {info['name']}"
                 )
         if url.scheme == "https":
+            # Secure
             label(f"traefik.http.routers.{router_name}.rule={rule}")
             label(f"traefik.http.routers.{router_name}.entrypoints=web-secure")
             label(f"traefik.http.routers.{router_name}.tls.certresolver=default")
+            label(f"traefik.http.routers.{router_name}.tls.options=intermediate")
+            label(f"traefik.http.routers.{router_name}.middlewares=hsts-header@file")
+            # Redirect
             label(f"traefik.http.routers.{router_insec}.rule={rule}")
             label(f"traefik.http.routers.{router_insec}.entrypoints=web")
             label(

--- a/mypaas/server/_traefik.py
+++ b/mypaas/server/_traefik.py
@@ -107,27 +107,13 @@ traefik_config = """
 [api]
   dashboard = true
 
-# Enable Let's Encrypt
+# Enable Let's Encrypt. Use EC256 because https://github.com/almarklein/mypaas/pull/24
 [certificatesResolvers.default.acme]
   email = "EMAIL"
   keyType = "EC256"
   storage = "acme.json"
   [certificatesResolvers.default.acme.httpchallenge]
     entrypoint = "web"
-
-# https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
-# https://ssl-config.mozilla.org/#server=traefik&version=2.4.2&config=intermediate&guideline=5.6
-[tls.options]
-  [tls.options.intermediate]
-    minVersion = "VersionTLS12"
-    cipherSuites = [
-      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
-      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
-    ]
 
 # Process metrics (use the influxDB protocol, because it sends aggregates)
 [metrics]
@@ -171,6 +157,19 @@ traefik_staticroutes = """
   [http.middlewares.hsts-header.headers]
     [http.middlewares.hsts-header.headers.customResponseHeaders]
       Strict-Transport-Security = "max-age=63072000"
+
+# Better security. For details see https://github.com/almarklein/mypaas/pull/25
+[tls.options]
+  [tls.options.intermediate]
+    minVersion = "VersionTLS12"
+    cipherSuites = [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+    ]
 
 # You can update/add users here and then 'mypaas server restart traefik'
 # Create a password hash using e.g. 'openssl passwd -apr1'

--- a/mypaas/server/_traefik.py
+++ b/mypaas/server/_traefik.py
@@ -115,6 +115,20 @@ traefik_config = """
   [certificatesResolvers.default.acme.httpchallenge]
     entrypoint = "web"
 
+# https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+# https://ssl-config.mozilla.org/#server=traefik&version=2.4.2&config=intermediate&guideline=5.6
+[tls.options]
+  [tls.options.intermediate]
+    minVersion = "VersionTLS12"
+    cipherSuites = [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
+    ]
+
 # Process metrics (use the influxDB protocol, because it sends aggregates)
 [metrics]
   [metrics.influxDB]

--- a/mypaas/server/_traefik.py
+++ b/mypaas/server/_traefik.py
@@ -168,6 +168,9 @@ traefik_staticroutes = """
 [http.middlewares]
   [http.middlewares.https-redirect.redirectscheme]
     scheme = "https"
+  [http.middlewares.hsts-header.headers]
+    [http.middlewares.hsts-header.headers.customResponseHeaders]
+      Strict-Transport-Security = "max-age=63072000"
 
 # You can update/add users here and then 'mypaas server restart traefik'
 # Create a password hash using e.g. 'openssl passwd -apr1'


### PR DESCRIPTION
from https://github.com/almarklein/mypaas/pull/24#issuecomment-778943216
cc @lilahtovmoon 

Relevant docs/notes:
* Mozilla distinguishes 3 levels of security/compatibility, it seems most reasonable to go with the recommended *intermediate compatibility*: https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
* Mozilla even has a template config file for Traefik that we can copy code from: https://ssl-config.mozilla.org/#server=traefik&version=2.4.2&config=intermediate&guideline=5.6
* Traefik docs on TLS: https://doc.traefik.io/traefik/https/tls/
* We already redirect http to https.
* Traefik docs say that _With TLS 1.3, the cipher suites are not configurable (all supported cipher suites are safe in this case)_ -> The specified cipher suites are for 1.2 only.


Also fixes some branch names (we renamed `master` to `main` recently), and fix a bug in the scaling deploy for cases in which there are no old containers for that service.