### PR TITLE
pull the latest images for Dockerfile FROM declarations

### DIFF
--- a/mypaas/server/_deploy.py
+++ b/mypaas/server/_deploy.py
@@ -258,7 +258,7 @@ def _deploy_no_scale(container_infos, deploy_dir, service_name, prepared_cmd):
     time.sleep(1)
 
     yield "building image"
-    dockercall("build", "-t", image_name, deploy_dir)
+    dockercall("build", "--pull", "-t", image_name, deploy_dir)
 
     # There typically is one, but there may be more, if we had failed
     # deploys or if previously deployed with scale > 1
@@ -310,7 +310,7 @@ def _deploy_scale(container_infos, deploy_dir, service_name, prepared_cmd, scale
     time.sleep(1)
 
     yield "building image"
-    dockercall("build", "-t", image_name, deploy_dir)
+    dockercall("build", "--pull", "-t", image_name, deploy_dir)
 
     old_ids = get_id_name_for_this_service(container_infos)
     unique = str(int(time.time()))


### PR DESCRIPTION
This is important if the deploy is using a pre-built image where you're using the "latest" tag and want it to fetch the latest version rather than re-deploying what it has.

As the deploy docs note, a simple dockerfile like `FROM registry.example.com/your/image:tag` can let you deploy a pre-built image, but if you're using the "latest" tag, `docker build` won't re-fetch the image without `--pull`.

https://github.com/almarklein/mypaas/blob/main/docs/deploying.md#pushing-a-deployment