### PR TITLE
support for openssh

### DIFF
--- a/example_services/benchmark/server.py
+++ b/example_services/benchmark/server.py
@@ -12,7 +12,7 @@ stats_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
 
 def send_stats(rtime):
-    """ Send request stats over UPD to a stats server. """
+    """Send request stats over UPD to a stats server."""
     stats = {"group": os.getenv("MYPAAS_SERVICE", "")}
     stats["requests|count"] = 1
     stats["rtime|num|s"] = float(rtime)

--- a/example_services/hello-world/server.py
+++ b/example_services/hello-world/server.py
@@ -12,7 +12,7 @@ stats_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
 
 def send_stats(request, status_code=None, rtime=None, is_page=None):
-    """ Send request stats over UPD to a stats server. """
+    """Send request stats over UPD to a stats server."""
     p = request.path
     stats = {"group": os.getenv("MYPAAS_SERVICE", "")}
     stats["requests|count"] = 1

--- a/mypaas/client/_keys.py
+++ b/mypaas/client/_keys.py
@@ -185,5 +185,7 @@ def get_private_key():
 
 def _show_public_key(public_key):
     pyperclip.copy(public_key.to_str())
+    print()
+    print(public_key.to_str())
     print(public_text)
     print("\nKeypair fingerprint: " + public_key.get_id())

--- a/mypaas/utils/_crypto.py
+++ b/mypaas/utils/_crypto.py
@@ -29,11 +29,17 @@ class PrivateKey:
     def from_str(cls, s, password):
         """Load a private RSA key from a string."""
         assert isinstance(s, str)
-        private_key = serialization.load_pem_private_key(
-            s.replace("_", "\n").encode(),
-            password=password.encode() if password else None,
-            backend=default_backend(),
-        )
+        if "OPENSSH" in s[:100]:
+            private_key = serialization.load_ssh_private_key(
+                s.encode(),
+                password=password.encode() if password else None,
+            )
+        else:
+            private_key = serialization.load_pem_private_key(
+                s.replace("_", "\n").encode(),
+                password=password.encode() if password else None,
+                backend=default_backend(),
+            )
         return PrivateKey(private_key)
 
     def to_str(self, password):


### PR DESCRIPTION
This adds support for using existing RSA keys in openssh format. Also, `key_get` prints the public key, because the clipboard does not seems to be cleared when the process ends (on ubuntu/popos).