### PR TITLE
Fix agregation resolution

### DIFF
--- a/mypaas/stats/collector.py
+++ b/mypaas/stats/collector.py
@@ -104,9 +104,9 @@ class StatsCollector:
             nchars = 20  # 1-second res
             if ndays <= 1:
                 nchars == 15  # 10-minute res
-            elif ndays <= 8:
+            elif ndays <= 6:
                 nchars = 13  # 1-hour res
-            elif ndays <= 170:
+            elif ndays <= 150:
                 nchars = 10  # 1-day res
             else:
                 nchars = 7  # 1-month res

--- a/mypaas/stats/collector.py
+++ b/mypaas/stats/collector.py
@@ -101,12 +101,15 @@ class StatsCollector:
             data = monitor.get_aggregations(first_day, final_day)
 
             # Determine level of aggregation: none, hour, day, month
-            nchars = 20
-            keys = {aggr["time_key"] for aggr in data}
-            for n in [16, 15, 13, 10, 7]:  # min, 10 min, hour, day, month
-                if len(keys) > 150:
-                    nchars = n
-                    keys = {key[:nchars] for key in keys}
+            nchars = 20  # 1-second res
+            if ndays <= 1:
+                nchars == 15  # 10-minute res
+            elif ndays <= 8:
+                nchars = 13  # 1-hour res
+            elif ndays <= 170:
+                nchars = 10  # 1-day res
+            else:
+                nchars = 7  # 1-month res
 
             # Merge aggr's that have the same key.
             data2 = [{"time_key": "x"}]

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -423,7 +423,7 @@ def test_collector_aggr():
     assert foo_num == 2
 
     # And if we look at this on a higher scale, the bins should merge
-    units = collector.get_data(["aa"], 6, 0)["aa"]
+    units = collector.get_data(["aa"], 14, 0)["aa"]
     foo_sum = sum(unit.get("foo|count", 0) for unit in units)
     foo_max = max(unit.get("foo|count", 0) for unit in units)
     foo_num = sum("foo|count" in unit for unit in units)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -378,6 +378,60 @@ def test_collector():
     assert collector.get_groups() == ("system", "aa", "bb", "zz")
 
 
+def test_collector_aggr():
+    clean_db()
+
+    collector = StatsCollector(db_dir)
+    assert collector.get_groups() == ()
+
+    # Put one count via the collector
+    collector.put("aa", {"foo|count": 1})
+
+    # Get assocuated monitor and put two more in
+    monitor = collector._monitors["aa"]
+    collector.put("aa", {"foo|count": 2})
+
+    # Now we should have three
+    units = collector.get_data(["aa"], 1, 0)["aa"]
+    foo_sum = sum(unit.get("foo|count", 0) for unit in units)
+    foo_max = max(unit.get("foo|count", 0) for unit in units)
+    foo_num = sum("foo|count" in unit for unit in units)
+    assert foo_sum == 3
+    assert foo_max == 3
+    assert foo_num == 1
+
+    # --
+
+    # Artificially move current aggregation backwards in time
+    earlier = time.time() - 30 * 60  # 30 minutes ago
+    time_key = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(earlier))
+    monitor._current_aggr["time_key"] = time_key
+    monitor._current_aggr["time_start"] = earlier
+    monitor._current_aggr["time_stop"] = monitor._current_time_stop = earlier + 60
+
+    # Push one 2 more counts
+    collector.put("aa", {"foo|count": 2})
+
+    # Now we should have 5, in two bins
+    time.sleep(0.1)  # Give helper thread time to process
+    units = collector.get_data(["aa"], 1, 0)["aa"]
+    foo_sum = sum(unit.get("foo|count", 0) for unit in units)
+    foo_max = max(unit.get("foo|count", 0) for unit in units)
+    foo_num = sum("foo|count" in unit for unit in units)
+    assert foo_sum == 5
+    assert foo_max == 3
+    assert foo_num == 2
+
+    # And if we look at this on a higher scale, the bins should merge
+    units = collector.get_data(["aa"], 6, 0)["aa"]
+    foo_sum = sum(unit.get("foo|count", 0) for unit in units)
+    foo_max = max(unit.get("foo|count", 0) for unit in units)
+    foo_num = sum("foo|count" in unit for unit in units)
+    assert foo_sum == 5
+    assert foo_max == 5
+    assert foo_num == 1
+
+
 # %% Server
 
 


### PR DESCRIPTION
The aggregation resolution was only based on the number of "samples", so with sparse signals the resolution could be high, even if the scale is high, resulting in odd figures. 